### PR TITLE
Add testing for timestamp formats and CI action workflow

### DIFF
--- a/.github/workflows/Python Version Testing.yml
+++ b/.github/workflows/Python Version Testing.yml
@@ -11,6 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 

--- a/.github/workflows/Python Version Testing.yml
+++ b/.github/workflows/Python Version Testing.yml
@@ -1,0 +1,29 @@
+name: Version Testing
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+        python -m pip install -r requirements.txt
+    - name: Test with tox
+      run: tox -e py

--- a/tests/test_timestamp_formats.py
+++ b/tests/test_timestamp_formats.py
@@ -6,7 +6,8 @@ from logmerger.timestamp_wrapper import TimestampedLineTransformer
 local_time = datetime.now().astimezone()
 local_tz = local_time.tzinfo
 
-def _test_timestamp_format_parsing(string_date, expected_datetime):
+
+def _test_timestamp_format_parsing(string_date: str, expected_datetime: datetime):
     transformer = TimestampedLineTransformer.make_transformer_from_sample_line(
         string_date
     )
@@ -63,5 +64,5 @@ def _test_timestamp_format_parsing(string_date, expected_datetime):
         ),
     ],
 )
-def test_timestamp_format_parsing(string_date, expected_datetime):
+def test_timestamp_format_parsing(string_date: str, expected_datetime: datetime):
     _test_timestamp_format_parsing(string_date, expected_datetime)

--- a/tests/test_timestamp_formats.py
+++ b/tests/test_timestamp_formats.py
@@ -1,9 +1,22 @@
+from pprint import pprint
 import pytest
+
 from datetime import datetime, timezone, timedelta
 from logmerger.timestamp_wrapper import TimestampedLineTransformer
 
 local_time = datetime.now().astimezone()
 local_tz = local_time.tzinfo
+
+def _test_timestamp_format_parsing(string_date, expected_datetime):
+    transformer = TimestampedLineTransformer.make_transformer_from_sample_line(
+        string_date
+    )
+
+    parsed_datetime, _ = transformer(string_date)
+    parsed_datetime = parsed_datetime.astimezone(timezone.utc)
+    pprint(parsed_datetime, width=200)
+    pprint(expected_datetime, width=200)
+    assert parsed_datetime == expected_datetime
 
 
 @pytest.mark.parametrize(
@@ -50,13 +63,5 @@ local_tz = local_time.tzinfo
         ),
     ],
 )
-def test_make_transformer_from_sample_line(string_date, expected_datetime):
-    transformer = TimestampedLineTransformer.make_transformer_from_sample_line(
-        string_date
-    )
-
-    parsed_datetime, _ = transformer(string_date)
-
-    parsed_datetime = parsed_datetime.astimezone(timezone.utc)
-
-    assert parsed_datetime == expected_datetime
+def test_timestamp_format_parsing(string_date, expected_datetime):
+    _test_timestamp_format_parsing(string_date, expected_datetime)

--- a/tests/test_timestamp_formats.py
+++ b/tests/test_timestamp_formats.py
@@ -1,4 +1,3 @@
-from pprint import pprint
 import pytest
 
 from datetime import datetime, timezone, timedelta
@@ -14,8 +13,9 @@ def _test_timestamp_format_parsing(string_date, expected_datetime):
 
     parsed_datetime, _ = transformer(string_date)
     parsed_datetime = parsed_datetime.astimezone(timezone.utc)
-    pprint(parsed_datetime, width=200)
-    pprint(expected_datetime, width=200)
+    print(repr(string_date))
+    print("Parsed time  :", parsed_datetime)
+    print("Expected time:", expected_datetime)
     assert parsed_datetime == expected_datetime
 
 

--- a/tests/test_timestamp_formats.py
+++ b/tests/test_timestamp_formats.py
@@ -1,0 +1,62 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from logmerger.timestamp_wrapper import TimestampedLineTransformer
+
+local_time = datetime.now().astimezone()
+local_tz = local_time.tzinfo
+
+
+@pytest.mark.parametrize(
+    "string_date, expected_datetime",
+    [
+        (
+            "2023-07-14 08:00:01,000Z Log",
+            datetime(2023, 7, 14, 8, 0, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "2023-07-14 08:00:01,123+0200 Log",
+            datetime(2023, 7, 14, 8, 0, 1, 123000, tzinfo=timezone(timedelta(hours=2))),
+        ),
+        (
+            "2023-07-14 08:00:01.000Z Log",
+            datetime(2023, 7, 14, 8, 0, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "2023-07-14 08:00:01.123+0200 Log",
+            datetime(2023, 7, 14, 8, 0, 1, 123000, tzinfo=timezone(timedelta(hours=2))),
+        ),
+        (
+            "2023-07-14 08:00:01 Log", 
+            datetime(2023, 7, 14, 8, 0, 1, tzinfo=local_tz)),
+        (
+            "2023-07-14T08:00:01,000Z Log",
+            datetime(2023, 7, 14, 8, 0, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "Jul 14 08:00:01 Log",
+            datetime(datetime.now().year, 7, 14, 8, 0, 1, tzinfo=local_tz),
+        ),
+        (
+            "1694561169.550987 Log",
+            datetime.fromtimestamp(1694561169.550987, tz=timezone.utc),
+        ),
+        (
+            "1694561169550 Log",
+            datetime.fromtimestamp(1694561169550 / 1000, tz=timezone.utc),
+        ),
+        (
+            "1694561169 Log",
+            datetime.fromtimestamp(1694561169, tz=timezone.utc),
+        ),
+    ],
+)
+def test_make_transformer_from_sample_line(string_date, expected_datetime):
+    transformer = TimestampedLineTransformer.make_transformer_from_sample_line(
+        string_date
+    )
+
+    parsed_datetime, _ = transformer(string_date)
+
+    parsed_datetime = parsed_datetime.astimezone(timezone.utc)
+
+    assert parsed_datetime == expected_datetime


### PR DESCRIPTION
This adds the tests for the different formats. As of this PR, it fails on 3.9 and 3.10 since the `fromisoformat` was made more powerful in 3.11.

To help with the testing, I also created a basic CI action that will test on all available python versions that are supported. If you don't want to include this quite yet, let me know, and I will remove it from the PR. You can see a sample run here: https://github.com/RTnhN/logmerger/actions/runs/11080227626