### PR TITLE
Add JsonL-Format as possible logformat

### DIFF
--- a/files/log8.jsonl
+++ b/files/log8.jsonl
@@ -1,0 +1,12 @@
+{"timestamp": "2023-07-14 08:00:01", "level": "WARN", "message":"Connection lost due to timeout"}
+{"timestamp": "2023-07-14 08:00:04", "level": "CRITICAL", "message": "Request processed unsuccessfully", "stacktrace": "Something went wrong\nTraceback (last line is latest):\n    sample.py: line 32\n        divide(100, 0)\n    sample.py: line 8\n        return a / b\nZeroDivisionError: division by zero"}
+{"timestamp": "2023-07-14 08:00:06", "level": "INFO", "message": "User authentication failed"}
+{"timestamp": "2023-07-14 08:00:08", "level": "DEBUG", "message": "Starting data synchronization"}
+{"timestamp": "2023-07-14 08:00:11", "level": "INFO", "message": "Processing incoming request"}
+{"timestamp": "2023-07-14 08:00:11", "level": "INFO", "message": "Processing incoming request (a little more...)"}
+{"timestamp": "2023-07-14 08:00:14", "level": "DEBUG", "message": "Performing database backup"}
+{"timestamp": "2023-07-14 08:00:16", "level": "WARN", "message": "Invalid input received: missing required field"}
+{"timestamp": "2023-07-14 08:00:19", "level": "ERROR", "message": "Failed to connect to remote server"}
+{"timestamp": "2023-07-14 08:00:22", "level": "INFO", "message": "Sending email notification"}
+{"timestamp": "2023-07-14 08:00:25", "level": "WARN", "message": "Slow response time detected"}
+{"timestamp": "2023-07-14 08:00:27", "level": "INFO", "message": "Data synchronization completed"}

--- a/files/log9.jsonl
+++ b/files/log9.jsonl
@@ -1,0 +1,12 @@
+{"level": "WARN", "LOG_TIME": "2023-07-14 08:00:01", "message":"Connection lost due to timeout"}
+{"level": "CRITICAL", "LOG_TIME": "2023-07-14 08:00:04", "message": "Request processed unsuccessfully", "stacktrace": "Something went wrong\nTraceback (last line is latest):\n    sample.py: line 32\n        divide(100, 0)\n    sample.py: line 8\n        return a / b\nZeroDivisionError: division by zero"}
+{"level": "INFO", "LOG_TIME": "2023-07-14 08:00:06", "message": "User authentication failed"}
+{"level": "DEBUG", "LOG_TIME": "2023-07-14 08:00:08", "message": "Starting data synchronization"}
+{"level": "INFO", "LOG_TIME": "2023-07-14 08:00:11", "message": "Processing incoming request"}
+{"level": "INFO", "LOG_TIME": "2023-07-14 08:00:11", "message": "Processing incoming request (a little more...)"}
+{"level": "DEBUG", "LOG_TIME": "2023-07-14 08:00:14", "message": "Performing database backup"}
+{"level": "WARN", "LOG_TIME": "2023-07-14 08:00:16", "message": "Invalid input received: missing required field"}
+{"level": "ERROR", "LOG_TIME": "2023-07-14 08:00:19", "message": "Failed to connect to remote server"}
+{"level": "INFO", "LOG_TIME": "2023-07-14 08:00:22", "message": "Sending email notification"}
+{"level": "WARN", "LOG_TIME": "2023-07-14 08:00:25", "message": "Slow response time detected"}
+{"level": "INFO", "LOG_TIME": "2023-07-14 08:00:27", "message": "Data synchronization completed"}

--- a/logmerger/file_reading.py
+++ b/logmerger/file_reading.py
@@ -270,15 +270,14 @@ class JsonLFileReader(FileReader):
         self._iter = self.iter_file()
 
     @staticmethod
-    def _find_dt_col(d: dict[str, Any], previous_key: str | None):
+    def _find_dt_col(d: dict[str, Any], previous_key: str | None)-> tuple[str, Any]:
         if previous_key is not None:
             value = d.get(previous_key)
             if value is not None:
                 return previous_key, value
         for key, val in d.items():
             try:
-                tt = TimestampedLineTransformer.make_transformer_from_sample_line(val + " ")
-                print(tt)
+                tt = TimestampedLineTransformer.make_transformer_from_sample_line(str(val) + " ")
             except ValueError:
                 continue
             return key, val

--- a/logmerger/file_reading.py
+++ b/logmerger/file_reading.py
@@ -273,8 +273,7 @@ class JsonLFileReader(FileReader):
     def _find_dt_col(d: dict[str, Any], previous_key: str | None)-> tuple[str, Any]:
         if previous_key is not None:
             value = d.get(previous_key)
-            if value is not None:
-                return previous_key, value
+            return previous_key, value
         for key, val in d.items():
             try:
                 tt = TimestampedLineTransformer.make_transformer_from_sample_line(str(val) + " ")

--- a/logmerger/file_reading.py
+++ b/logmerger/file_reading.py
@@ -272,7 +272,7 @@ class JsonLFileReader(FileReader):
     @staticmethod
     def _find_dt_col(d: dict[str, Any], previous_key: str | None)-> tuple[str, Any]:
         if previous_key is not None:
-            value = d.get(previous_key)
+            value = d.get(previous_key, "")
             return previous_key, value
         for key, val in d.items():
             try:


### PR DESCRIPTION
This PR adds support for jsonL (or ndjson) logs. 
Files are found if they are called with the file ending jsonl.

Currently is the timestamp searched in all top-level keys in the json objects.
Each key is printed to its own line (\n are not escaped). That's the easiest option for showing json objects. In the future it is possible to allow more complex options.

Additionally there is a small example file, which can be read with the new Reader.